### PR TITLE
Nit: Fix javadoc in DetachedVertexProperty

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedVertexProperty.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/structure/util/detached/DetachedVertexProperty.java
@@ -144,7 +144,7 @@ public class DetachedVertexProperty<V> extends DetachedElement<VertexProperty<V>
     }
 
     /**
-     * Provides a way to construct an immutable {@link DetachedEdge}.
+     * Provides a way to construct an immutable {@link DetachedVertexProperty}.
      */
     public static DetachedVertexProperty.Builder build() {
         return new Builder(new DetachedVertexProperty());


### PR DESCRIPTION
## Summary
- Corrected javadoc reference in DetachedVertexProperty

## Testing
- N/A